### PR TITLE
Add missing documentation comments

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,7 +1,12 @@
 package goeventqueue
 
+// EventName identifies the name of an event that will be published or
+// consumed by the queue.
 type EventName string
 
+// Event represents a unit of information that can be passed through the
+// queue. Implementations should provide the event name and its associated
+// payload data.
 type Event interface {
 	GetName() EventName
 	GetData() interface{}

--- a/job.go
+++ b/job.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// JobConfig controls the retry behaviour when executing a job handler.
 type JobConfig struct {
 	MaxBackOff int64
 }
@@ -35,6 +36,8 @@ func (j *job) Run(ctx context.Context, data interface{}) error {
 	}
 }
 
+// NewJob creates a job that will run the given handler applying the retry
+// configuration provided.
 func NewJob(handler Handler, cfg JobConfig) *job {
 	return &job{
 		handler: handler,

--- a/publisher.go
+++ b/publisher.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+// Publisher posts events to a Queue so that they may be processed by
+// subscribers.
 type Publisher interface {
 	Publish(ctx context.Context, event Event) error
 }
@@ -23,6 +25,7 @@ func (p publisher) Publish(ctx context.Context, event Event) error {
 	return nil
 }
 
+// NewPublisher returns a Publisher that writes events to the provided Queue.
 func NewPublisher(q Queue) Publisher {
 	return &publisher{
 		queue: q,

--- a/queue.go
+++ b/queue.go
@@ -1,5 +1,7 @@
 package goeventqueue
 
+// Queue provides access to an underlying channel used to deliver events to
+// subscribers.
 type Queue interface {
 	GetEventChan() chan Event
 }
@@ -12,6 +14,9 @@ func (q *localQueue) GetEventChan() chan Event {
 	return q.events
 }
 
+// NewLocalQueue creates a new in-memory queue with the provided buffer size.
+// The queue implementation is safe for concurrent use by multiple publishers
+// and subscribers.
 func NewLocalQueue(size int) Queue {
 	return &localQueue{
 		events: make(chan Event, size),

--- a/subscriber.go
+++ b/subscriber.go
@@ -6,17 +6,21 @@ import (
 	"sync"
 )
 
+// Subscriber consumes events from a Queue and dispatches them to registered
+// handlers.
 type Subscriber interface {
 	Start(ctx context.Context)
 	Register(name EventName, handler Handler)
 	WithLogger(l Logger)
 }
 
+// Config defines parameters that control how the subscriber dispatches work.
 type Config struct {
 	MaxGoRoutine int64
 	MaxRetry     int64
 }
 
+// Handler processes event data received by the Subscriber.
 type Handler func(ctx context.Context, data interface{}) error
 
 type subscriber struct {
@@ -91,6 +95,8 @@ func (s *subscriber) startWorker(ctx context.Context, eQueue chan Event) {
 	}
 }
 
+// NewSubscriber creates a Subscriber that reads from the provided Queue using
+// the supplied configuration.
 func NewSubscriber(q Queue, cfg Config) Subscriber {
 	return &subscriber{
 		queue:           q,


### PR DESCRIPTION
## Summary
- add Go doc comments for exported types and constructors
- keep code formatted

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b78974fd08328b600ac832b4cd325